### PR TITLE
Fix incorrect GetHashCode implementation in test project and minor clean up to avoid allocations for unused values.

### DIFF
--- a/src/Marvin.StreamExtensions/StreamExtensions.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensions.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace Marvin.StreamExtensions
 {
@@ -224,7 +224,7 @@ namespace Marvin.StreamExtensions
             this Stream stream, 
             T objectToWrite)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
         }
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Marvin.StreamExtensions
             T objectToWrite,
             Encoding encoding)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace Marvin.StreamExtensions
             Encoding encoding, 
             int bufferSize)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, encoding, bufferSize, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, false, false);
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace Marvin.StreamExtensions
             int bufferSize, 
             bool leaveOpen)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Marvin.StreamExtensions
             T objectToWrite, 
             bool resetStream)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace Marvin.StreamExtensions
             Encoding encoding,
             bool resetStream)
         {
-            SerializeToJsonAndWrite<T>(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
         }
         
         /// <summary>

--- a/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Marvin.StreamExtensions
 {
@@ -23,7 +23,7 @@ namespace Marvin.StreamExtensions
             this Stream stream, 
             T objectToWrite)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Marvin.StreamExtensions
             T objectToWrite,
             Encoding encoding)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Marvin.StreamExtensions
             Encoding encoding, 
             int bufferSize)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, encoding, bufferSize, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Marvin.StreamExtensions
             int bufferSize, 
             bool leaveOpen)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Marvin.StreamExtensions
             T objectToWrite, 
             bool resetStream)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Marvin.StreamExtensions
             Encoding encoding, 
             bool resetStream)
         {
-            await SerializeToJsonAndWriteAsync<T>(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
         }
 
         /// <summary>

--- a/test/Marvin.StreamExtensions.Test/Person.cs
+++ b/test/Marvin.StreamExtensions.Test/Person.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Marvin.StreamExtensions.Test
+﻿namespace Marvin.StreamExtensions.Test
 {
     public class Person
     {
@@ -17,14 +13,9 @@ namespace Marvin.StreamExtensions.Test
         // generate hashcode
         public override int GetHashCode()
         {
-            unchecked
-            {
-                var hashCode = 13; 
-                var myStrHashCode =
-                    !string.IsNullOrEmpty(Name) ?
-                        Name.GetHashCode() : 0; 
-                return hashCode;
-            }
+            return !string.IsNullOrEmpty(Name)
+                                    ? Name.GetHashCode()
+                                    : 0;
         }
     }
 }

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -145,7 +145,7 @@ namespace Marvin.StreamExtensions.Test
             var httpClient = new HttpClient(bounceInputHttpMessageHandlerMock.Object); 
 
             var memoryContentStream = new MemoryStream();
-            memoryContentStream.SerializeToJsonAndWrite<Person>(person, new UTF8Encoding(), 1024, true, true);
+            memoryContentStream.SerializeToJsonAndWrite(person, new UTF8Encoding(), 1024, true, true);
 
             using (var request = new HttpRequestMessage(
                 HttpMethod.Post,
@@ -197,7 +197,7 @@ namespace Marvin.StreamExtensions.Test
             var httpClient = new HttpClient(bounceInputHttpMessageHandlerMock.Object);
 
             var memoryContentStream = new MemoryStream();
-            await memoryContentStream.SerializeToJsonAndWriteAsync<Person>(person, new UTF8Encoding(), 1024, true, true);
+            await memoryContentStream.SerializeToJsonAndWriteAsync(person, new UTF8Encoding(), 1024, true, true);
 
             using (var request = new HttpRequestMessage(
                 HttpMethod.Post,

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -56,7 +56,7 @@ namespace Marvin.StreamExtensions.Test
 
                     using (var response = await httpClient.SendAsync(request))
                     {
-                        var stream = await response.Content.ReadAsStreamAsync();
+                        _ = await response.Content.ReadAsStreamAsync();
 
                         response.EnsureSuccessStatusCode();                        
                         personAfterResponse = JsonConvert.DeserializeObject<Person>(await response.Content.ReadAsStringAsync());                         
@@ -108,7 +108,7 @@ namespace Marvin.StreamExtensions.Test
 
                     using (var response = await httpClient.SendAsync(request))
                     {
-                        var stream = await response.Content.ReadAsStreamAsync();
+                        _ = await response.Content.ReadAsStreamAsync();
 
                         response.EnsureSuccessStatusCode();
                         personAfterResponse = JsonConvert.DeserializeObject<Person>(await response.Content.ReadAsStringAsync());
@@ -159,7 +159,7 @@ namespace Marvin.StreamExtensions.Test
 
                     using (var response = await httpClient.SendAsync(request))
                     {
-                        var stream = await response.Content.ReadAsStreamAsync();
+                        _ = await response.Content.ReadAsStreamAsync();
 
                         response.EnsureSuccessStatusCode();
                         personAfterResponse = JsonConvert.DeserializeObject<Person>(
@@ -211,7 +211,7 @@ namespace Marvin.StreamExtensions.Test
 
                     using (var response = await httpClient.SendAsync(request))
                     {
-                        var stream = await response.Content.ReadAsStreamAsync();
+                        _ = await response.Content.ReadAsStreamAsync();
 
                         response.EnsureSuccessStatusCode();
                         personAfterResponse = JsonConvert.DeserializeObject<Person>(

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -1,7 +1,3 @@
-using Moq;
-using Moq.Protected;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +5,10 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Marvin.StreamExtensions.Test
@@ -19,7 +19,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task SerializeInputToStream_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();
@@ -71,7 +71,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task SerializeInputToStream_Async_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();
@@ -122,7 +122,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task SerializeTypedInputToStream_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();
@@ -174,7 +174,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task SerializeTypedInputToStream_Async_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();
@@ -227,7 +227,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task DeserializeTypedResponseFromStream_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();
@@ -269,7 +269,7 @@ namespace Marvin.StreamExtensions.Test
         public async Task DeserializeResponseFromStream_MustMatchInput()
         {
             var person = new Person() { Name = "Lord Flashheart" };
-            var personAfterResponse = new Person();
+            Person personAfterResponse;
 
             // create mocked HttpMessageHandler 
             var bounceInputHttpMessageHandlerMock = new Mock<HttpMessageHandler>();


### PR DESCRIPTION
ReSharper brought up some warnings about unused values. This PR cleans these up. In the course of the clean up I found that the GetHashCode implementation for the Person class always returned the value 13 for all Person objects. I was able to correct and simplify this at the same time.