### PR TITLE
Use && instead of & operator

### DIFF
--- a/src/Marvin.StreamExtensions/StreamExtensions.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensions.cs
@@ -354,7 +354,7 @@ namespace Marvin.StreamExtensions
             }
 
             // after writing, set the stream to position 0
-            if (resetStream & stream.CanSeek)
+            if (resetStream && stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }
@@ -495,7 +495,7 @@ namespace Marvin.StreamExtensions
             }
 
             // after writing, set the stream to position 0
-            if (resetStream & stream.CanSeek)
+            if (resetStream && stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }

--- a/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
@@ -153,7 +153,7 @@ namespace Marvin.StreamExtensions
             }
 
             // after writing, set the stream to position 0
-            if (resetStream & stream.CanSeek)
+            if (resetStream && stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }
@@ -294,7 +294,7 @@ namespace Marvin.StreamExtensions
             }
 
             // after writing, set the stream to position 0
-            if (resetStream & stream.CanSeek)
+            if (resetStream && stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }


### PR DESCRIPTION
Use && instead of & operator in order to short-circuit the property
access to 'CanSeek' in case no stream reset is requested.