### PR TITLE
SerializeToJsonAndWriteAsync cancellation

### DIFF
--- a/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -11,34 +12,38 @@ namespace Marvin.StreamExtensions
     /// </summary>
     public static partial class StreamExtensions
     {
-        // note: there aren't async versions of ReadAndDeserialize as Json.NET currently doesn't support that.
+		// note: there aren't async versions of ReadAndDeserialize as Json.NET currently doesn't support that.
 
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        public static async Task SerializeToJsonAndWriteAsync<T>(
-            this Stream stream, 
-            T objectToWrite)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        public static async Task SerializeToJsonAndWriteAsync<T>(
+		/// <summary>
+		/// Serialize (to Json) and write to the stream
+		/// </summary>
+		/// <typeparam name="T">The type the object to serialize/write</typeparam>
+		/// <param name="stream">The stream</param>
+		/// <param name="objectToWrite">The object to write to the stream</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+		public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
-            Encoding encoding)
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+        }
+
+		/// <summary>
+		/// Serialize (to Json) and write to the stream
+		/// </summary>
+		/// <typeparam name="T">The type the object to serialize/write</typeparam>
+		/// <param name="stream">The stream</param>
+		/// <param name="objectToWrite">The object to write to the stream</param>
+		/// <param name="encoding">The encoding to use</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+		public static async Task SerializeToJsonAndWriteAsync<T>(
+            this Stream stream, 
+            T objectToWrite,
+            Encoding encoding,
+			CancellationToken cancellationToken = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
 
         /// <summary>
@@ -49,13 +54,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
-            int bufferSize)
+            int bufferSize,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
         }
 
         /// <summary>
@@ -67,14 +74,16 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
             int bufferSize, 
-            bool leaveOpen)
+            bool leaveOpen,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
         }
 
         /// <summary>
@@ -84,12 +93,14 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite, 
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
 
         /// <summary>
@@ -100,13 +111,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
 
         /// <summary>
@@ -119,13 +132,15 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding,
             int bufferSize,
             bool leaveOpen,
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {
@@ -148,7 +163,7 @@ namespace Marvin.StreamExtensions
                 {
                     var jsonSerializer = new JsonSerializer();
                     jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    await jsonTextWriter.FlushAsync();
+                    await jsonTextWriter.FlushAsync(cancellationToken);
                 }
             }
 
@@ -164,42 +179,29 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
-        public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream, 
-            object objectToWrite)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream,
-            object objectToWrite, 
-            Encoding encoding)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="bufferSize">The size of the buffer</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
-            Encoding encoding, 
-            int bufferSize)
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        public static async Task SerializeToJsonAndWriteAsync(
+            this Stream stream,
+            object objectToWrite, 
+            Encoding encoding,
+			CancellationToken cancellationToken = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
 
         /// <summary>
@@ -210,15 +212,36 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
-        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding, 
             int bufferSize,
-            bool leaveOpen)
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        public static async Task SerializeToJsonAndWriteAsync(
+            this Stream stream, 
+            object objectToWrite,
+            Encoding encoding, 
+            int bufferSize,
+            bool leaveOpen,
+			CancellationToken cancellationToken = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
         }
 
         /// <summary>
@@ -227,12 +250,14 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
 
         /// <summary>
@@ -242,13 +267,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding,
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
 
         /// <summary>
@@ -260,13 +287,15 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding,
             int bufferSize,
             bool leaveOpen,
-            bool resetStream)
+            bool resetStream,
+			CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {
@@ -289,7 +318,7 @@ namespace Marvin.StreamExtensions
                 {
                     var jsonSerializer = new JsonSerializer();
                     jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    await jsonTextWriter.FlushAsync();
+                    await jsonTextWriter.FlushAsync(cancellationToken);
                 }
             }
 

--- a/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
@@ -12,36 +12,36 @@ namespace Marvin.StreamExtensions
     /// </summary>
     public static partial class StreamExtensions
     {
-		// note: there aren't async versions of ReadAndDeserialize as Json.NET currently doesn't support that.
+        // note: there aren't async versions of ReadAndDeserialize as Json.NET currently doesn't support that.
 
-		/// <summary>
-		/// Serialize (to Json) and write to the stream
-		/// </summary>
-		/// <typeparam name="T">The type the object to serialize/write</typeparam>
-		/// <param name="stream">The stream</param>
-		/// <param name="objectToWrite">The object to write to the stream</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
-		public static async Task SerializeToJsonAndWriteAsync<T>(
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
 
-		/// <summary>
-		/// Serialize (to Json) and write to the stream
-		/// </summary>
-		/// <typeparam name="T">The type the object to serialize/write</typeparam>
-		/// <param name="stream">The stream</param>
-		/// <param name="objectToWrite">The object to write to the stream</param>
-		/// <param name="encoding">The encoding to use</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
-		public static async Task SerializeToJsonAndWriteAsync<T>(
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
@@ -54,13 +54,13 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
             int bufferSize,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
         }
@@ -74,14 +74,14 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
             int bufferSize, 
             bool leaveOpen,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
         }
@@ -93,12 +93,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite, 
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
@@ -111,13 +111,13 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
             Encoding encoding, 
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
@@ -132,7 +132,7 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream, 
             T objectToWrite,
@@ -140,7 +140,7 @@ namespace Marvin.StreamExtensions
             int bufferSize,
             bool leaveOpen,
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {
@@ -179,11 +179,11 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
@@ -194,12 +194,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream,
             object objectToWrite, 
             Encoding encoding,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
         }
@@ -212,13 +212,13 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding, 
             int bufferSize,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
         }
@@ -232,14 +232,14 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding, 
             int bufferSize,
             bool leaveOpen,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
         }
@@ -250,12 +250,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
@@ -267,13 +267,13 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
             Encoding encoding,
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
         }
@@ -287,7 +287,7 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-		/// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream, 
             object objectToWrite,
@@ -295,7 +295,7 @@ namespace Marvin.StreamExtensions
             int bufferSize,
             bool leaveOpen,
             bool resetStream,
-			CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             if (stream == null)
             {

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -307,5 +307,21 @@ namespace Marvin.StreamExtensions.Test
             }
             Assert.Equal(person, personAfterResponse);
         }
-    }
+
+		[Fact]
+		public async Task SerializeTypedInputToStream_Async_CanceledThrowsTaskCanceledException ()
+		{
+			var person = new Person();
+			var cancellationTokenSource = new CancellationTokenSource();
+			cancellationTokenSource.Cancel();
+
+			using (var memoryStream = new MemoryStream())
+			{
+				await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+					// test simple overload to also ensure the more complex overload is passed the token
+					await memoryStream.SerializeToJsonAndWriteAsync(person, cancellationTokenSource.Token)
+				);
+			}
+		}
+	}
 }

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -309,7 +309,7 @@ namespace Marvin.StreamExtensions.Test
         }
 
 		[Fact]
-		public async Task SerializeTypedInputToStream_Async_CanceledThrowsTaskCanceledException ()
+		public async Task SerializeTypedInputToStream_Async_CanceledThrowsTaskCanceledException()
 		{
 			var person = new Person();
 			var cancellationTokenSource = new CancellationTokenSource();

--- a/test/Marvin.StreamExtensions.Test/StreamTests.cs
+++ b/test/Marvin.StreamExtensions.Test/StreamTests.cs
@@ -308,20 +308,20 @@ namespace Marvin.StreamExtensions.Test
             Assert.Equal(person, personAfterResponse);
         }
 
-		[Fact]
-		public async Task SerializeTypedInputToStream_Async_CanceledThrowsTaskCanceledException()
-		{
-			var person = new Person();
-			var cancellationTokenSource = new CancellationTokenSource();
-			cancellationTokenSource.Cancel();
+        [Fact]
+        public async Task SerializeTypedInputToStream_Async_CanceledThrowsTaskCanceledException()
+        {
+            var person = new Person();
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
 
-			using (var memoryStream = new MemoryStream())
-			{
-				await Assert.ThrowsAsync<TaskCanceledException>(async () =>
-					// test simple overload to also ensure the more complex overload is passed the token
-					await memoryStream.SerializeToJsonAndWriteAsync(person, cancellationTokenSource.Token)
-				);
-			}
-		}
-	}
+            using (var memoryStream = new MemoryStream())
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                    // test simple overload to also ensure the more complex overload is passed the token
+                    await memoryStream.SerializeToJsonAndWriteAsync(person, cancellationTokenSource.Token)
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added optional cancellationtoken parameter to each overload of .SerializeToJsonAndWriteAsync() and pass the token to jsonTextWriter.FlushAsync(). Addresses Issue #4 