### PR TITLE
Adding JsonSerializerSettings  to extension methods

### DIFF
--- a/src/Marvin.StreamExtensions/StreamExtensions.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using Newtonsoft.Json;
+using System;
 using System.IO;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Marvin.StreamExtensions
 {
@@ -17,10 +17,10 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
-            this Stream stream)
+            this Stream stream, JsonSerializerSettings jsonSerializerSettings = default)
         {
-            return ReadAndDeserializeFromJson<T>(stream, new UTF8Encoding(), true, 
-                Defaults.DefaultBufferSizeOnRead, false);
+            return ReadAndDeserializeFromJson<T>(stream, new UTF8Encoding(), true,
+                Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -31,11 +31,11 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
-            this Stream stream, 
-            Encoding encoding)
+            this Stream stream,
+            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson<T>(stream, encoding, true,
-                Defaults.DefaultBufferSizeOnRead, false);
+                Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -47,10 +47,11 @@ namespace Marvin.StreamExtensions
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
             this Stream stream,
-            bool detectEncodingFromByteOrderMarks)
+            bool detectEncodingFromByteOrderMarks,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson<T>(stream, new UTF8Encoding(),
-                detectEncodingFromByteOrderMarks, Defaults.DefaultBufferSizeOnRead, false);
+                detectEncodingFromByteOrderMarks, Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -66,10 +67,11 @@ namespace Marvin.StreamExtensions
             this Stream stream,
             Encoding encoding,
             bool detectEncodingFromByteOrderMarks,
-            int bufferSize)
+            int bufferSize,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson<T>(stream, encoding,
-                detectEncodingFromByteOrderMarks, bufferSize, false);
+                detectEncodingFromByteOrderMarks, bufferSize, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -87,31 +89,24 @@ namespace Marvin.StreamExtensions
             Encoding encoding,
             bool detectEncodingFromByteOrderMarks,
             int bufferSize,
-            bool leaveOpen)
+            bool leaveOpen,
+            JsonSerializerSettings jsonSerializerSettings = default
+            )
         {
             if (stream == null)
-            {
                 throw new ArgumentNullException(nameof(stream));
-            }
 
             if (!stream.CanRead)
-            {
                 throw new NotSupportedException("Can't read from this stream.");
-            }
 
             if (encoding == null)
-            {
                 throw new ArgumentNullException(nameof(encoding));
-            }
 
-            using (var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen))
-            {
-                using (var jsonTextReader = new JsonTextReader(streamReader))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    return jsonSerializer.Deserialize<T>(jsonTextReader);
-                }
-            }
+            using var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
+            using var jsonTextReader = new JsonTextReader(streamReader);
+
+            var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            return jsonSerializer.Deserialize<T>(jsonTextReader);
         }
 
         /// <summary>
@@ -120,10 +115,11 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
-            this Stream stream)
+            this Stream stream,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson(stream, new UTF8Encoding(), true,
-                Defaults.DefaultBufferSizeOnRead, false);
+                Defaults.DefaultBufferSizeOnRead, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -133,11 +129,12 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
-            this Stream stream, 
-            Encoding encoding)
+            this Stream stream,
+            Encoding encoding,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson(stream, encoding, true,
-                Defaults.DefaultBufferSizeOnRead, false);
+                Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -148,10 +145,11 @@ namespace Marvin.StreamExtensions
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
-           bool detectEncodingFromByteOrderMarks)
+            bool detectEncodingFromByteOrderMarks,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson(stream, new UTF8Encoding(),
-                detectEncodingFromByteOrderMarks, Defaults.DefaultBufferSizeOnRead, false);
+                detectEncodingFromByteOrderMarks, Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
         }
 
 
@@ -167,10 +165,11 @@ namespace Marvin.StreamExtensions
             this Stream stream,
             Encoding encoding,
             bool detectEncodingFromByteOrderMarks,
-            int bufferSize)
+            int bufferSize,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson(stream, encoding,
-                detectEncodingFromByteOrderMarks, bufferSize, false);
+                detectEncodingFromByteOrderMarks, bufferSize, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -187,31 +186,23 @@ namespace Marvin.StreamExtensions
             Encoding encoding,
             bool detectEncodingFromByteOrderMarks,
             int bufferSize,
-            bool leaveOpen)
+            bool leaveOpen,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
-            {
                 throw new ArgumentNullException(nameof(stream));
-            }
 
             if (!stream.CanRead)
-            {
                 throw new NotSupportedException("Can't read from this stream.");
-            }
 
             if (encoding == null)
-            {
                 throw new ArgumentNullException(nameof(encoding));
-            }
 
-            using (var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen))
-            {
-                using (var jsonTextReader = new JsonTextReader(streamReader))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    return jsonSerializer.Deserialize(jsonTextReader);
-                }
-            }
+            using var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
+            using var jsonTextReader = new JsonTextReader(streamReader);
+
+            var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            return jsonSerializer.Deserialize(jsonTextReader);
         }
 
         /// <summary>
@@ -221,8 +212,9 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
-            T objectToWrite)
+            this Stream stream,
+            T objectToWrite,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
         }
@@ -235,11 +227,11 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
+            this Stream stream,
             T objectToWrite,
-            Encoding encoding)
+            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -251,65 +243,66 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
-            T objectToWrite,
-            Encoding encoding, 
-            int bufferSize)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, false, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="bufferSize">The size of the buffer</param>
-        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
-        public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
-            T objectToWrite,
-            Encoding encoding, 
-            int bufferSize, 
-            bool leaveOpen)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
-            T objectToWrite, 
-            bool resetStream)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <typeparam name="T">The type the object to serialize/write</typeparam>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
+            this Stream stream,
             T objectToWrite,
             Encoding encoding,
-            bool resetStream)
+            int bufferSize,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, false, false, jsonSerializerSettings);
         }
-        
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        public static void SerializeToJsonAndWrite<T>(
+            this Stream stream,
+            T objectToWrite,
+            Encoding encoding,
+            int bufferSize,
+            bool leaveOpen, JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        public static void SerializeToJsonAndWrite<T>(
+            this Stream stream,
+            T objectToWrite,
+            bool resetStream, JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <typeparam name="T">The type the object to serialize/write</typeparam>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        public static void SerializeToJsonAndWrite<T>(
+            this Stream stream,
+            T objectToWrite,
+            Encoding encoding,
+            bool resetStream, JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, jsonSerializerSettings);
+        }
+
         /// <summary>
         /// Serialize (to Json) and write to the stream
         /// </summary>
@@ -321,37 +314,29 @@ namespace Marvin.StreamExtensions
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         public static void SerializeToJsonAndWrite<T>(
-            this Stream stream, 
+            this Stream stream,
             T objectToWrite,
             Encoding encoding,
             int bufferSize,
             bool leaveOpen,
-            bool resetStream)
+            bool resetStream,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
-            {
                 throw new ArgumentNullException(nameof(stream));
-            }
 
             if (!stream.CanWrite)
-            {
                 throw new NotSupportedException("Can't write to this stream.");
-            }
 
             if (encoding == null)
-            {
                 throw new ArgumentNullException(nameof(encoding));
-            }
 
-            using (var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen))
-            {
-                using (var jsonTextWriter = new JsonTextWriter(streamWriter))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    jsonTextWriter.Flush();
-                }
-            }
+            using var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+            using var jsonTextWriter = new JsonTextWriter(streamWriter);
+
+            var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
+            jsonTextWriter.Flush();
 
             // after writing, set the stream to position 0
             if (resetStream && stream.CanSeek)
@@ -366,10 +351,10 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         public static void SerializeToJsonAndWrite(
-            this Stream stream, 
-            object objectToWrite)
+            this Stream stream,
+            object objectToWrite, JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -379,27 +364,11 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         public static void SerializeToJsonAndWrite(
-            this Stream stream, 
+            this Stream stream,
             object objectToWrite,
-            Encoding encoding)
+            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="bufferSize">The size of the buffer</param>
-        public static void SerializeToJsonAndWrite(
-            this Stream stream, 
-            object objectToWrite,
-            Encoding encoding, 
-            int bufferSize)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -409,45 +378,14 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
-        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         public static void SerializeToJsonAndWrite(
-            this Stream stream, 
+            this Stream stream,
             object objectToWrite,
-            Encoding encoding, 
-            int bufferSize, 
-            bool leaveOpen)
+            Encoding encoding,
+            int bufferSize,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        public static void SerializeToJsonAndWrite(
-            this Stream stream, 
-            object objectToWrite, 
-            bool resetStream)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        public static void SerializeToJsonAndWrite(
-            this Stream stream, 
-            object objectToWrite,
-            Encoding encoding, 
-            bool resetStream)
-        {
-            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream);
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, false, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -458,14 +396,66 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         public static void SerializeToJsonAndWrite(
-            this Stream stream, 
+            this Stream stream,
             object objectToWrite,
             Encoding encoding,
             int bufferSize,
             bool leaveOpen,
-            bool resetStream)
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        public static void SerializeToJsonAndWrite(
+            this Stream stream,
+            object objectToWrite,
+            bool resetStream,
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        public static void SerializeToJsonAndWrite(
+            this Stream stream,
+            object objectToWrite,
+            Encoding encoding,
+            bool resetStream,
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        public static void SerializeToJsonAndWrite(
+            this Stream stream,
+            object objectToWrite,
+            Encoding encoding,
+            int bufferSize,
+            bool leaveOpen,
+            bool resetStream,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
             {
@@ -482,15 +472,13 @@ namespace Marvin.StreamExtensions
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            using (var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen))
-            {
-                using (var jsonTextWriter = new JsonTextWriter(streamWriter))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    jsonTextWriter.Flush();
-                }
-            }
+            using var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+
+            using var jsonTextWriter = new JsonTextWriter(streamWriter);
+
+            var jsonSerializer = jsonSerializerSettings == null ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
+            jsonTextWriter.Flush();
 
             // after writing, set the stream to position 0
             if (resetStream && stream.CanSeek)

--- a/src/Marvin.StreamExtensions/StreamExtensions.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensions.cs
@@ -15,9 +15,11 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <typeparam name="T">The object type</typeparam>
         /// <param name="stream">The stream</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
-            this Stream stream, JsonSerializerSettings jsonSerializerSettings = default)
+            this Stream stream,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson<T>(stream, new UTF8Encoding(), true,
                 Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
@@ -29,10 +31,12 @@ namespace Marvin.StreamExtensions
         /// <typeparam name="T">The object type</typeparam>
         /// <param name="stream">The stream</param>
         /// <param name="encoding">The encoding to use</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
             this Stream stream,
-            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
+            Encoding encoding,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             return ReadAndDeserializeFromJson<T>(stream, encoding, true,
                 Defaults.DefaultBufferSizeOnRead, false, jsonSerializerSettings);
@@ -44,6 +48,7 @@ namespace Marvin.StreamExtensions
         /// <typeparam name="T">The object type</typeparam>
         /// <param name="stream">The stream</param>
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
             this Stream stream,
@@ -62,6 +67,7 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
         /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
             this Stream stream,
@@ -83,6 +89,7 @@ namespace Marvin.StreamExtensions
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamReader object is disposed</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>An object of type T</returns>
         public static T ReadAndDeserializeFromJson<T>(
             this Stream stream,
@@ -113,6 +120,7 @@ namespace Marvin.StreamExtensions
         /// Read from the stream and deserialize (assuming Json content).
         /// </summary>
         /// <param name="stream">The stream</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
@@ -127,6 +135,7 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="encoding">The encoding to use</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
@@ -142,6 +151,7 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
@@ -160,6 +170,7 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
         /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
@@ -180,6 +191,7 @@ namespace Marvin.StreamExtensions
         /// <param name="detectEncodingFromByteOrderMarks">True to detect encoding from byte order marks, false otherwise</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamReader object is disposed</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         /// <returns>The deserialized object</returns>
         public static object ReadAndDeserializeFromJson(
             this Stream stream,
@@ -211,12 +223,13 @@ namespace Marvin.StreamExtensions
         /// <typeparam name="T">The type the object to serialize/write</typeparam>
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
             JsonSerializerSettings jsonSerializerSettings = default)
         {
-            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false);
+            SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -226,10 +239,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
-            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
+            Encoding encoding,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
@@ -242,6 +257,7 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
@@ -261,12 +277,14 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
             Encoding encoding,
             int bufferSize,
-            bool leaveOpen, JsonSerializerSettings jsonSerializerSettings = default)
+            bool leaveOpen,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, jsonSerializerSettings);
         }
@@ -278,10 +296,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
-            bool resetStream, JsonSerializerSettings jsonSerializerSettings = default)
+            bool resetStream,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, jsonSerializerSettings);
         }
@@ -294,6 +314,7 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
@@ -313,6 +334,7 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite<T>(
             this Stream stream,
             T objectToWrite,
@@ -350,9 +372,11 @@ namespace Marvin.StreamExtensions
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
-            object objectToWrite, JsonSerializerSettings jsonSerializerSettings = default)
+            object objectToWrite,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
@@ -363,10 +387,12 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,
-            Encoding encoding, JsonSerializerSettings jsonSerializerSettings = default)
+            Encoding encoding,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             SerializeToJsonAndWrite(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, jsonSerializerSettings);
         }
@@ -378,6 +404,7 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,
@@ -396,6 +423,7 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,
@@ -413,6 +441,7 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,
@@ -429,6 +458,7 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,
@@ -448,6 +478,7 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static void SerializeToJsonAndWrite(
             this Stream stream,
             object objectToWrite,

--- a/src/Marvin.StreamExtensions/StreamExtensions.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensions.cs
@@ -97,21 +97,26 @@ namespace Marvin.StreamExtensions
             bool detectEncodingFromByteOrderMarks,
             int bufferSize,
             bool leaveOpen,
-            JsonSerializerSettings jsonSerializerSettings = default
-            )
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
+
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
 
             if (!stream.CanRead)
+            {
                 throw new NotSupportedException("Can't read from this stream.");
+            }
 
             if (encoding == null)
+            {
                 throw new ArgumentNullException(nameof(encoding));
+            }
 
             using var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
             using var jsonTextReader = new JsonTextReader(streamReader);
-
             var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
             return jsonSerializer.Deserialize<T>(jsonTextReader);
         }
@@ -202,13 +207,19 @@ namespace Marvin.StreamExtensions
             JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
 
             if (!stream.CanRead)
+            {
                 throw new NotSupportedException("Can't read from this stream.");
+            }
 
             if (encoding == null)
+            {
                 throw new ArgumentNullException(nameof(encoding));
+            }
 
             using var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
             using var jsonTextReader = new JsonTextReader(streamReader);
@@ -344,14 +355,21 @@ namespace Marvin.StreamExtensions
             bool resetStream,
             JsonSerializerSettings jsonSerializerSettings = default)
         {
+            
             if (stream == null)
+            {
                 throw new ArgumentNullException(nameof(stream));
+            }
 
             if (!stream.CanWrite)
+            {
                 throw new NotSupportedException("Can't write to this stream.");
+            }
 
             if (encoding == null)
+            {
                 throw new ArgumentNullException(nameof(encoding));
+            }
 
             using var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
             using var jsonTextWriter = new JsonTextWriter(streamWriter);

--- a/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
+++ b/src/Marvin.StreamExtensions/StreamExtensionsAsync.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Marvin.StreamExtensions
 {
@@ -107,12 +107,10 @@ namespace Marvin.StreamExtensions
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            using (var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen))
-            using (var jsonTextReader = new JsonTextReader(streamReader))
-            {
-                var jToken = await JToken.LoadAsync(jsonTextReader);
-                return jToken.ToObject<T>();
-            }
+            using var streamReader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks, bufferSize, leaveOpen);
+            using var jsonTextReader = new JsonTextReader(streamReader);
+            var jToken = await JToken.LoadAsync(jsonTextReader);
+            return jToken.ToObject<T>();
         }
 
         /// <summary>
@@ -122,12 +120,14 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
-            this Stream stream, 
+            this Stream stream,
             T objectToWrite,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -138,13 +138,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite,
             Encoding encoding,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -156,14 +158,16 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite,
-            Encoding encoding, 
+            Encoding encoding,
             int bufferSize,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -176,15 +180,17 @@ namespace Marvin.StreamExtensions
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite,
-            Encoding encoding, 
-            int bufferSize, 
+            Encoding encoding,
+            int bufferSize,
             bool leaveOpen,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -195,13 +201,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
-            T objectToWrite, 
+            T objectToWrite,
             bool resetStream,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -213,14 +221,16 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite,
-            Encoding encoding, 
+            Encoding encoding,
             bool resetStream,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -234,6 +244,7 @@ namespace Marvin.StreamExtensions
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync<T>(
             this Stream stream,
             T objectToWrite,
@@ -241,7 +252,8 @@ namespace Marvin.StreamExtensions
             int bufferSize,
             bool leaveOpen,
             bool resetStream,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
             {
@@ -258,15 +270,12 @@ namespace Marvin.StreamExtensions
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            using (var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen))
-            {
-                using (var jsonTextWriter = new JsonTextWriter(streamWriter))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    await jsonTextWriter.FlushAsync(cancellationToken);
-                }
-            }
+            using var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+            using var jsonTextWriter = new JsonTextWriter(streamWriter);
+            var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
+            await jsonTextWriter.FlushAsync(cancellationToken);
+
 
             // after writing, set the stream to position 0
             if (resetStream && stream.CanSeek)
@@ -281,12 +290,14 @@ namespace Marvin.StreamExtensions
         /// <param name="stream">The stream</param>
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream, 
+            this Stream stream,
             object objectToWrite,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -296,13 +307,15 @@ namespace Marvin.StreamExtensions
         /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="encoding">The encoding to use</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream,
-            object objectToWrite, 
+            object objectToWrite,
             Encoding encoding,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -313,68 +326,16 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
-        public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream,
-            object objectToWrite,
-            Encoding encoding, 
-            int bufferSize,
-            CancellationToken cancellationToken = default)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="bufferSize">The size of the buffer</param>
-        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream,
             object objectToWrite,
             Encoding encoding,
             int bufferSize,
-            bool leaveOpen,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
-        public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream,
-            object objectToWrite,
-            bool resetStream,
-            CancellationToken cancellationToken = default)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
-        }
-
-        /// <summary>
-        /// Serialize (to Json) and write to the stream
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="objectToWrite">The object to write to the stream</param>
-        /// <param name="encoding">The encoding to use</param>
-        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
-        public static async Task SerializeToJsonAndWriteAsync(
-            this Stream stream,
-            object objectToWrite,
-            Encoding encoding,
-            bool resetStream,
-            CancellationToken cancellationToken = default)
-        {
-            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken);
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, false, false, cancellationToken, jsonSerializerSettings);
         }
 
         /// <summary>
@@ -385,8 +346,69 @@ namespace Marvin.StreamExtensions
         /// <param name="encoding">The encoding to use</param>
         /// <param name="bufferSize">The size of the buffer</param>
         /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
+        public static async Task SerializeToJsonAndWriteAsync(
+            this Stream stream,
+            object objectToWrite,
+            Encoding encoding,
+            int bufferSize,
+            bool leaveOpen,
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, bufferSize, leaveOpen, false, cancellationToken, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
         /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
+        public static async Task SerializeToJsonAndWriteAsync(
+            this Stream stream,
+            object objectToWrite,
+            bool resetStream,
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, new UTF8Encoding(), Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
+        public static async Task SerializeToJsonAndWriteAsync(
+            this Stream stream,
+            object objectToWrite,
+            Encoding encoding,
+            bool resetStream,
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
+        {
+            await SerializeToJsonAndWriteAsync(stream, objectToWrite, encoding, Defaults.DefaultBufferSizeOnWrite, false, resetStream, cancellationToken, jsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize (to Json) and write to the stream
+        /// </summary>
+        /// <param name="stream">The stream</param>
+        /// <param name="objectToWrite">The object to write to the stream</param>
+        /// <param name="encoding">The encoding to use</param>
+        /// <param name="bufferSize">The size of the buffer</param>
+        /// <param name="leaveOpen">True to leave the stream open after the (internally used) StreamWriter object is disposed</param>
+        /// <param name="resetStream">True to reset the stream to position 0 after writing, false otherwise</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is System.Threading.CancellationToken.None.</param>
+        /// <param name="jsonSerializerSettings">The JsonSerialization setting beeing used for serialization. In default state it will use default settings from Newtonsoft.Json.JsonConvert.DefaultSettings</param>
         public static async Task SerializeToJsonAndWriteAsync(
             this Stream stream,
             object objectToWrite,
@@ -394,7 +416,8 @@ namespace Marvin.StreamExtensions
             int bufferSize,
             bool leaveOpen,
             bool resetStream,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            JsonSerializerSettings jsonSerializerSettings = default)
         {
             if (stream == null)
             {
@@ -411,15 +434,11 @@ namespace Marvin.StreamExtensions
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            using (var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen))
-            {
-                using (var jsonTextWriter = new JsonTextWriter(streamWriter))
-                {
-                    var jsonSerializer = new JsonSerializer();
-                    jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
-                    await jsonTextWriter.FlushAsync(cancellationToken);
-                }
-            }
+            using var streamWriter = new StreamWriter(stream, encoding, bufferSize, leaveOpen);
+            using var jsonTextWriter = new JsonTextWriter(streamWriter);
+            var jsonSerializer = jsonSerializerSettings == default ? JsonSerializer.Create() : JsonSerializer.Create(jsonSerializerSettings);
+            jsonSerializer.Serialize(jsonTextWriter, objectToWrite);
+            await jsonTextWriter.FlushAsync(cancellationToken);
 
             // after writing, set the stream to position 0
             if (resetStream && stream.CanSeek)


### PR DESCRIPTION
Solving the #12 issue by adding JsonSerializerSettings to the API of extension methods.

- All of the methods are backward compatible and have default value for the JsonSerializerSettings which is the default of the Newtonsoft.Json.JsonConvert.DefaultSettings.
- Creation of JsonSerializer are using JsonSerializer.Create method now.